### PR TITLE
feat(util/glpk_wrapper): exact arith, check error

### DIFF
--- a/src/icp/lp_icp.h
+++ b/src/icp/lp_icp.h
@@ -25,12 +25,14 @@ along with dReal. If not, see <http://www.gnu.org/licenses/>.
 #include "util/scoped_vec.h"
 #include "contractor/contractor.h"
 #include "opensmt/smtsolvers/SMTConfig.h"
+#include "util/glpk_wrapper.h"
 
 namespace dreal {
 
 class lp_icp {
 private:
     static BranchHeuristic & defaultHeuristic;
+    static bool is_lp_sat(glpk_wrapper & lp, box & solution, SMTConfig const & config);
 public:
     // TODO(damien): the contractor contains both the linear and nonlinear constraints but it only needs the nonlinear ...
     static box solve(box b, contractor & ctc,

--- a/src/util/glpk_wrapper.h
+++ b/src/util/glpk_wrapper.h
@@ -34,12 +34,14 @@ namespace dreal {
 
 class glpk_wrapper {
 private:
+    // solver type
+    enum solver_type_t {SIMPLEX, INTERIOR, EXACT};
     // for indexing variables
     box domain;
     // the lp
     glp_prob *lp;
     // whether to use simplex or interior point
-    bool simplex;
+    solver_type_t solver_type;
 
     unsigned get_index(Enode * e) const {
         return domain.get_index(e);
@@ -48,6 +50,10 @@ private:
     void set_constraint(int index, Enode * const e);
 
     void init_problem();
+
+    double get_row_value(int row);
+
+    bool check_unsat_error_kkt(double precision);
 
 public:
     explicit glpk_wrapper(box const & b);
@@ -68,18 +74,18 @@ public:
     void set_minimize();
     void set_maximize();
 
+    void get_error_bounds(double * errors);
+    bool certify_unsat(double precision);
+
     void use_simplex();
     void use_interior_point();
+    void use_exact();
 
     int print_to_file(const char *fname);
 
     static bool is_linear(Enode * const e);
     static bool is_expr_linear(Enode * const e);
 };
-/*
-    push: () → ()
-    pop: () → ()
-*/
 
 }  // namespace dreal
 #endif


### PR DESCRIPTION
For the LP-ICP, now when the LP says unsat, it checks the numerical error. If the LP is not precise enough then it uses a rational simplex. The goal is to avoid the LP-ICP say unsat if a problem is sat.

- add support to call ℚ simplex
- check that the LP numerical error is small enough (unsat is really unsat)
- use the exact simplex when the numerical error is too large