### PR TITLE
Add missing link libraries

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -811,6 +811,17 @@ else()
   add_library(dop STATIC ${DOP_SRCS})
 endif()
 
+if(BUILD_SHARED_LIBS)
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${DREAL_EXTRA_LINKER_FLAGS} ${EXTERNAL_LD_FLAGS}")
+
+  target_link_libraries(dreal ${EXTRA_LIBS})
+  if(${PYTHONLIBS_FOUND})
+    target_link_libraries(dop dreal ${PYTHON_LIBRARIES} ${EXTRA_LIBS})
+  else()
+    target_link_libraries(dop dreal ${EXTRA_LIBS})
+  endif()
+endif()
+
 add_dependencies(dop PICOSAT)
 add_dependencies(dop IBEX)
 add_dependencies(dop ADEPT)


### PR DESCRIPTION
Modify CMake logic to actually link the `dreal` and `dop` libraries to their dependencies. This fixes the build when `-Wl,--no-undefined` is used (which should always be usable aside from some rare, esoteric cases), and should also fix the issue mentioned in #51 where `dlopen`ing the library requires first `dlopen`ing its dependencies. It will also allow drastically simplifying the link line of `dreal.pc` when built shared, so that we aren't leaking our list of dependencies. (When built static, there is of course no such thing as private linking; we'll still need the full list in that case.)

Closes #316

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dreal/dreal3/318)
<!-- Reviewable:end -->
